### PR TITLE
Skal hente perioder som mangler oppdrag_id, men uten beløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/repository/PeriodeRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/repository/PeriodeRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.infotrygd.repository
 
 import no.nav.familie.ef.infotrygd.model.StønadType
+import no.nav.familie.ef.infotrygd.repository.RepositoryUtil.getNullableInt
 import no.nav.familie.ef.infotrygd.rest.api.InfotrygdAktivitetstype
 import no.nav.familie.ef.infotrygd.rest.api.InfotrygdEndringKode
 import no.nav.familie.ef.infotrygd.rest.api.InfotrygdOvergangsstønadKode
@@ -53,14 +54,14 @@ class PeriodeRepository(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             v.dato_innv_tom,
             s.dato_opphor,
             ef.barnt_utg,
-            (SELECT bg.belop FROM t_beregn_grl bg WHERE bg.vedtak_id = v.vedtak_id AND bg.type_belop = 'ARBM') inntektsgrunnlag
+            (SELECT bg.belop FROM t_beregn_grl bg WHERE bg.vedtak_id = v.vedtak_id AND bg.type_belop = 'ARBM') inntektsgrunnlag,
+            s.oppdrag_id
            FROM t_lopenr_fnr l
             JOIN t_stonad s ON s.person_lopenr = l.person_lopenr
             JOIN t_vedtak v ON v.stonad_id = s.stonad_id
             JOIN t_endring e ON e.vedtak_id = v.vedtak_id 
             JOIN t_ef ef ON ef.vedtak_id = v.vedtak_id
            WHERE l.personnr IN (:personIdenter)
-              AND s.oppdrag_id IS NOT NULL
               AND v.kode_rutine IN (:stønadskoder)
               AND v.dato_innv_fom < v.dato_innv_tom
            ORDER BY s.stonad_id ASC, vedtak_id ASC, dato_innv_fom DESC
@@ -94,7 +95,8 @@ class PeriodeRepository(private val jdbcTemplate: NamedParameterJdbcTemplate) {
                     stønadFom = rs.getDate("dato_innv_fom").toLocalDate(),
                     stønadTom = rs.getDate("dato_innv_tom").toLocalDate(),
                     opphørsdato = rs.getDate("dato_opphor")?.toLocalDate(),
-                    vedtakKodeResultat = rs.getString("kode_resultat").trim()
+                    vedtakKodeResultat = rs.getString("kode_resultat").trim(),
+                    oppdragId = rs.getNullableInt("oppdrag_id")
                 )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/repository/RepositoryUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/repository/RepositoryUtil.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.ef.infotrygd.repository
+
+import java.sql.ResultSet
+
+object RepositoryUtil {
+
+    fun ResultSet.getNullableInt(columnName: String): Int? {
+        val value = this.getInt(columnName)
+        return if (this.wasNull()) null else value
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/rest/api/Periode.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/rest/api/Periode.kt
@@ -42,7 +42,8 @@ data class Periode(
     val stønadTom: LocalDate,
     val opphørsdato: LocalDate?,
     val barnIdenter: List<String> = emptyList(),
-    val vedtakKodeResultat: String
+    val vedtakKodeResultat: String,
+    val oppdragId: Int?
 ) {
     fun erFortsattInnvilget() = vedtakKodeResultat == "FI"
 }

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/service/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/service/PeriodeService.kt
@@ -12,12 +12,21 @@ import org.springframework.stereotype.Service
 class PeriodeService(private val periodeRepository: PeriodeRepository) {
 
     fun hentPerioder(request: PeriodeRequest): Map<StønadType, List<Periode>> {
-        val perioder =
-            periodeRepository.hentPerioder(request).groupBy({ it.first }) { it.second }
-                .toMutableMap()
+        val perioder = periodeRepository.hentPerioder(request)
+            .filterNot { manglerOppdragIdOgHarBeløpOver0(it.second) }
+            .groupBy({ it.first }) { it.second }
+            .toMutableMap()
         perioder[BARNETILSYN] = hentBarnetilsynPerioderMedBarn(perioder)
         return perioder.map { it.key to it.value.sortedByDescending { it.stønadFom } }.toMap()
     }
+
+    /**
+     * Skal filtrere vekk perioder som mangler oppdragId, og har beløp over 0kr
+     * Først var det kommunisert at vi skulle filtrere vekk alle perioder som mangler oppdrag_id då disse ikke var iverksatte
+     * Vi fant senere ut at de som manglet oppdragId og hadde beløp 0 var besluttet, men ikke sendt til oppdrag
+     */
+    private fun manglerOppdragIdOgHarBeløpOver0(second: Periode) =
+        second.oppdragId == null && (second.engangsbeløp > 0 || second.månedsbeløp > 0)
 
     fun hentSammenslåttePerioder(request: PeriodeRequest): Map<StønadType, List<Periode>> {
         return hentPerioder(request).map { it.key to slåSammenPerioder(it.value) }.toMap()

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/service/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/service/PeriodeService.kt
@@ -13,7 +13,7 @@ class PeriodeService(private val periodeRepository: PeriodeRepository) {
 
     fun hentPerioder(request: PeriodeRequest): Map<StønadType, List<Periode>> {
         val perioder = periodeRepository.hentPerioder(request)
-            .filterNot { manglerOppdragIdOgHarBeløpOver0(it.second) }
+            .filter { harOppdragIdEller0beløp(it.second) }
             .groupBy({ it.first }) { it.second }
             .toMutableMap()
         perioder[BARNETILSYN] = hentBarnetilsynPerioderMedBarn(perioder)
@@ -25,8 +25,8 @@ class PeriodeService(private val periodeRepository: PeriodeRepository) {
      * Først var det kommunisert at vi skulle filtrere vekk alle perioder som mangler oppdrag_id då disse ikke var iverksatte
      * Vi fant senere ut at de som manglet oppdragId og hadde beløp 0 var besluttet, men ikke sendt til oppdrag
      */
-    private fun manglerOppdragIdOgHarBeløpOver0(second: Periode) =
-        second.oppdragId == null && (second.engangsbeløp > 0 || second.månedsbeløp > 0)
+    private fun harOppdragIdEller0beløp(periode: Periode) =
+        periode.oppdragId != null || (periode.engangsbeløp == 0 && periode.månedsbeløp == 0)
 
     fun hentSammenslåttePerioder(request: PeriodeRequest): Map<StønadType, List<Periode>> {
         return hentPerioder(request).map { it.key to slåSammenPerioder(it.value) }.toMap()

--- a/src/test/kotlin/no/nav/familie/ef/infotrygd/perioder/InfotrygdPeriodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/infotrygd/perioder/InfotrygdPeriodeTestUtil.kt
@@ -50,7 +50,8 @@ object InfotrygdPeriodeTestUtil {
             stønadTom = stønadTom,
             opphørsdato = opphørsdato,
             barnIdenter = barnIdenter,
-            vedtakKodeResultat = ""
+            vedtakKodeResultat = "",
+            oppdragId = 1
         )
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/infotrygd/service/PeriodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/infotrygd/service/PeriodeServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.infotrygd.rest.api.InfotrygdSakstype
 import no.nav.familie.ef.infotrygd.rest.api.Periode
 import no.nav.familie.ef.infotrygd.rest.api.PeriodeRequest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -20,12 +21,18 @@ internal class PeriodeServiceTest {
     val periodeRepository = mockk<PeriodeRepository>()
     val periodeService: PeriodeService = PeriodeService(periodeRepository)
 
+    private val request = PeriodeRequest(
+        personIdenter = setOf(FoedselsNr("01015450572")),
+        stønadstyper = setOf(BARNETILSYN, OVERGANGSSTØNAD)
+    )
+
+    @Before
+    fun setUp() {
+        every { periodeRepository.hentBarnForPerioder(any()) } returns emptyMap()
+    }
+
     @Test
     fun `Skal legge til barn på barnetilsyn - andre skal være uendret`() {
-        val request = PeriodeRequest(
-            personIdenter = setOf(FoedselsNr("01015450572")),
-            stønadstyper = setOf(BARNETILSYN, OVERGANGSSTØNAD)
-        )
         val uendretPeriode = lagPeriode()
         every { periodeRepository.hentPerioder(any()) } returns listOf(
             Pair(BARNETILSYN, lagPeriode(vedtakId = 35L)),
@@ -41,16 +48,11 @@ internal class PeriodeServiceTest {
 
     @Test
     fun `Ingen barnetilsynbarn funnet - skal ikke feile hvis det ikke finnes barn`() {
-        val request = PeriodeRequest(
-            personIdenter = setOf(FoedselsNr("01015450572")),
-            stønadstyper = setOf(BARNETILSYN, OVERGANGSSTØNAD)
-        )
         val uendretPeriode = lagPeriode()
         every { periodeRepository.hentPerioder(any()) } returns listOf(
             Pair(BARNETILSYN, lagPeriode(vedtakId = 35L)),
             Pair(OVERGANGSSTØNAD, uendretPeriode)
         )
-        every { periodeRepository.hentBarnForPerioder(any()) } returns emptyMap()
 
         val perioder = periodeService.hentPerioder(request = request)
         val barnetilsynPerioderHentet = perioder[BARNETILSYN]!!.first()
@@ -60,14 +62,16 @@ internal class PeriodeServiceTest {
 
     @Test
     fun `Ingen barnetilsynbarn funnet - skal bruke forrige periode sine barn hvis det finnes`() {
-        val request = PeriodeRequest(
-            personIdenter = setOf(FoedselsNr("01015450572")),
-            stønadstyper = setOf(BARNETILSYN, OVERGANGSSTØNAD)
-        )
         val uendretPeriode = lagPeriode()
         every { periodeRepository.hentPerioder(any()) } returns listOf(
-            Pair(BARNETILSYN, lagPeriode(vedtakId = 35L, "FI", stønadFom = LocalDate.MIN.plusDays(4), stønadTom = LocalDate.MAX)),
-            Pair(BARNETILSYN, lagPeriode(vedtakId = 34L, stønadFom = LocalDate.MIN, stønadTom = LocalDate.MIN.plusDays(3))),
+            Pair(
+                BARNETILSYN,
+                lagPeriode(vedtakId = 35L, "FI", stønadFom = LocalDate.MIN.plusDays(4), stønadTom = LocalDate.MAX)
+            ),
+            Pair(
+                BARNETILSYN,
+                lagPeriode(vedtakId = 34L, stønadFom = LocalDate.MIN, stønadTom = LocalDate.MIN.plusDays(3))
+            ),
             Pair(OVERGANGSSTØNAD, uendretPeriode)
         )
         every { periodeRepository.hentBarnForPerioder(any()) } returns mapOf(34L to listOf("123"))
@@ -78,11 +82,36 @@ internal class PeriodeServiceTest {
         assertThat(barnetilsynPerioderHentet[35L]!!.barnIdenter).isNotEmpty
     }
 
+    @Test
+    fun `skal filtrere vekk perioder som mangler oppdragId med beløp`() {
+        val perioderMedOppdragId = listOf(
+            lagPeriode(oppdragId = 1, månedsbeløp = 0, engangsbeløp = 1),
+            lagPeriode(oppdragId = 1, månedsbeløp = 1, engangsbeløp = 0),
+            lagPeriode(oppdragId = 1, månedsbeløp = 0, engangsbeløp = 0)
+        )
+        val periodeUtenOppdragIdUtenBeløp = lagPeriode(oppdragId = null, månedsbeløp = 0, engangsbeløp = 0)
+        val perioderUtenOppdragIdMedBeløp = listOf(
+            lagPeriode(oppdragId = null, månedsbeløp = 0, engangsbeløp = 1),
+            lagPeriode(oppdragId = null, månedsbeløp = 1, engangsbeløp = 0),
+            lagPeriode(oppdragId = null, månedsbeløp = 1, engangsbeløp = 1)
+        )
+
+        val dbPerioder = perioderMedOppdragId + periodeUtenOppdragIdUtenBeløp + perioderUtenOppdragIdMedBeløp
+        every { periodeRepository.hentPerioder(any()) } returns dbPerioder.map { Pair(OVERGANGSSTØNAD, it) }
+
+        val perioder = periodeService.hentPerioder(request).values.flatten()
+
+        assertThat(perioder).containsExactlyInAnyOrderElementsOf(perioderMedOppdragId + periodeUtenOppdragIdUtenBeløp)
+    }
+
     private fun lagPeriode(
         vedtakId: Long = 1,
         vedtakKodeResultat: String = "I",
         stønadFom: LocalDate = LocalDate.MIN,
-        stønadTom: LocalDate = LocalDate.MAX
+        stønadTom: LocalDate = LocalDate.MAX,
+        månedsbeløp: Int = 0,
+        engangsbeløp: Int = 0,
+        oppdragId: Int? = 1
     ) = Periode(
         personIdent = "123",
         sakstype = InfotrygdSakstype.SØKNAD,
@@ -93,17 +122,18 @@ internal class PeriodeServiceTest {
         stønadId = 0,
         vedtakId = vedtakId,
         vedtakstidspunkt = LocalDateTime.MIN,
-        engangsbeløp = 0,
+        engangsbeløp = engangsbeløp,
         inntektsgrunnlag = 0,
         inntektsreduksjon = 0,
         samordningsfradrag = 0,
         utgifterBarnetilsyn = 0,
-        månedsbeløp = 0,
+        månedsbeløp = månedsbeløp,
         startDato = LocalDate.MIN,
         stønadFom = stønadFom,
         stønadTom = stønadTom,
         opphørsdato = null,
         barnIdenter = emptyList(),
-        vedtakKodeResultat = vedtakKodeResultat
+        vedtakKodeResultat = vedtakKodeResultat,
+        oppdragId = oppdragId
     )
 }

--- a/src/test/kotlin/no/nav/familie/ef/infotrygd/testutils/InfotrygdPeriodeParser.kt
+++ b/src/test/kotlin/no/nav/familie/ef/infotrygd/testutils/InfotrygdPeriodeParser.kt
@@ -75,7 +75,8 @@ object InfotrygdPeriodeParser {
             aktivitetstype = null,
             startDato = LocalDate.now(),
             vedtakstidspunkt = LocalDateTime.now(),
-            vedtakKodeResultat = ""
+            vedtakKodeResultat = "",
+            oppdragId = 1
         )
 
     private fun getValue(row: Map<String, String>, key: String) = row[key]?.trim()


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10257

Skal filtrere vekk perioder som mangler oppdragId, og har beløp over 0kr
Først var det kommunisert at vi skulle filtrere vekk alle perioder som mangler oppdrag_id då disse ikke var iverksatte
Vi fant senere ut at de som manglet oppdragId og hadde beløp 0 var besluttet, men ikke sendt til oppdrag

* filtrering på oppdrag_id er fjernet fra query
* filtrering på oppdrag_id er lagt til i kotlinkode som sjekker mot stønadsbeløp

Bygger videre på 
* https://github.com/navikt/familie-ef-infotrygd/pull/17

