### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -23,7 +23,6 @@ spec:
   replicas: # Optional. Set min = max to disable autoscaling.
     min: 2 # minimum number of replicas.
     max: 5 # maximum number of replicas.
-    cpuThresholdPercentage: 50 # total cpu percentage threshold on deployment, at which point it will increase number of pods if current < max
   leaderElection: false # Optional. If true, a http endpoint will be available at $ELECTOR_PATH that return the current leader
   # Compare this value with the $HOSTNAME to see if the current instance is the leader
   preStopHookPath: "" # Optional. A HTTP GET will be issued to this endpoint at least once before the pod is terminated.
@@ -32,7 +31,6 @@ spec:
     enabled: false # Optional. When true, envoy-proxy sidecar will be injected into pod and https urls envvars will be rewritten
   resources: # Optional. See: http://kubernetes.io/docs/user-guide/compute-resources/
     limits:
-      cpu: 1500m # app will have its cpu usage throttled if exceeding this limit
       memory: 512Mi  # app will be killed if exceeding these limits
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 500m

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -23,7 +23,6 @@ spec:
   replicas: # Optional. Set min = max to disable autoscaling.
     min: 2 # minimum number of replicas.
     max: 5 # maximum number of replicas.
-    cpuThresholdPercentage: 50 # total cpu percentage threshold on deployment, at which point it will increase number of pods if current < max
   leaderElection: false # Optional. If true, a http endpoint will be available at $ELECTOR_PATH that return the current leader
   # Compare this value with the $HOSTNAME to see if the current instance is the leader
   preStopHookPath: "" # Optional. A HTTP GET will be issued to this endpoint at least once before the pod is terminated.
@@ -32,7 +31,6 @@ spec:
     enabled: false # Optional. When true, envoy-proxy sidecar will be injected into pod and https urls envvars will be rewritten
   resources: # Optional. See: http://kubernetes.io/docs/user-guide/compute-resources/
     limits:
-      cpu: 1500m # app will have its cpu usage throttled if exceeding this limit
       memory: 512Mi  # app will be killed if exceeding these limits
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)