### PR TITLE
Tving spring til å bruke versjon av tomcat-embed-core, netty-codec-dn…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,13 +51,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("io.micrometer:micrometer-core")
     implementation("io.micrometer:micrometer-registry-prometheus")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("net.ttddyy:datasource-proxy:1.11.0")
     implementation("no.nav.security:token-validation-spring:$tokenValidationVersion")
     implementation("no.nav.familie.kontrakter:enslig-forsorger:$kontrakterVersjon")
     implementation("no.nav.familie.kontrakter:felles:$kontrakterVersjon")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.springdoc:springdoc-openapi-ui:$springdocVersion")
     implementation("org.springdoc:springdoc-openapi-kotlin:$springdocVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:9.0")
@@ -73,6 +72,14 @@ dependencies {
     testImplementation("com.h2database:h2")
     testImplementation("io.mockk:mockk-jvm:$mockkVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+
+    // Kritisk sårbarhet importert via
+    constraints {
+        implementation("org.apache.tomcat.embed:tomcat-embed-core:11.0.22")
+        implementation("io.netty:netty-codec-dns:4.2.13.Final")
+        implementation("io.netty:netty-codec-http:4.2.13.Final")
+    }
+
 }
 
 val inputFiles = project.fileTree(mapOf("dir" to "src", "include" to "**/*.kt"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,10 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
+// Pga kritisk sårbarhet: legger til extra for å tvinge bruk av sikker versjon av netty og tomcat
+// Kan fjernes etter oppdatering av spring boot verson > 4.0.6
 extra["netty.version"] = "4.2.13.Final"
 extra["tomcat.version"] = "11.0.22"
-
 
 group = "no.nav"
 version = "0.0.1-SNAPSHOT"
@@ -76,14 +77,6 @@ dependencies {
     testImplementation("com.h2database:h2")
     testImplementation("io.mockk:mockk-jvm:$mockkVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-
-    // Kritisk sårbarhet importert via
-    constraints {
-        implementation("org.apache.tomcat.embed:tomcat-embed-core:11.0.22")
-        implementation("io.netty:netty-codec-dns:4.2.13.Final")
-        implementation("io.netty:netty-codec-http:4.2.13.Final")
-    }
-
 }
 
 val inputFiles = project.fileTree(mapOf("dir" to "src", "include" to "**/*.kt"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,10 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
+extra["netty.version"] = "4.2.13.Final"
+extra["tomcat.version"] = "11.0.22"
+
+
 group = "no.nav"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
Tving spring til å bruke versjon av tomcat-embed-core, netty-codec-dns og netty-codec-http uten kritiske sårbarheter.

Deployet i dev og testet:
<img width="582" height="81" alt="image" src="https://github.com/user-attachments/assets/8510c261-9e77-4ebf-a4f5-b02f3ab62817" />
