### PR TITLE
Ta i bruk ny servicebruker

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -39,7 +39,7 @@ spec:
   vault:
     enabled: true # Optional. If set to true fetch secrets from Secret Service and inject into the pods. todo link to doc.
     paths:
-      - kvPath: /oracle/data/dev/creds/infotrygd_efq-user
+      - kvPath: /oracle/data/dev/creds/ef_infotrygd_q1-user
         mountPath: /var/run/secrets/oracle/creds
   azure:
     application:


### PR DESCRIPTION
Infotrygd-teamet har i forbindelse med generell gjennomgang av retningslinjer for passord og passordpolicy i Oracle databasene, innført en ny service-bruker EF_INFOTRYGD_Q1 med lesetilgang til Oracle database INFOTRYGD_EFQ i Q1 miljø. Se repo vault-iac for tilhørende PR.