### PR TITLE
Prioriterer endringskode opphør dersom det finnes på vedtak.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/model/Endring.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/model/Endring.kt
@@ -4,7 +4,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
 
 @Suppress("unused") // brukes av hibernate for å generere hvilke tabeller som brukes
 @Entity
@@ -15,8 +14,4 @@ data class Endring(
     val id: Long,
     @Column(name = "KODE")
     val kode: String,
-    @Column(name = "OPPRETTET")
-    val opprettet: LocalDateTime?,
-    @Column(name = "OPPDATERT")
-    val oppdatert: LocalDateTime?,
 )

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/repository/PeriodeRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/repository/PeriodeRepository.kt
@@ -66,17 +66,6 @@ class PeriodeRepository(
            WHERE l.personnr IN (:personIdenter)
               AND v.kode_rutine IN (:stønadskoder)
               AND v.dato_innv_fom < v.dato_innv_tom
-              -- Et vedtak kan ha flere rader i t_endring (PK er vedtak_id og kode), for eksempel
-              -- når en sak i ettertid får en ny kode (opphørt eller overført ny løsning) i
-              -- tillegg til den opprinnelige. Vi velger da raden som sist ble oppdatert i
-              -- Infotrygd, for å reflektere den gjeldende statusen på vedtaket.
-              AND e.kode = (
-                  SELECT e2.kode
-                  FROM t_endring e2
-                  WHERE e2.vedtak_id = v.vedtak_id
-                  ORDER BY e2.oppdatert DESC NULLS LAST, e2.opprettet DESC NULLS LAST, e2.kode DESC
-                  FETCH FIRST 1 ROW ONLY
-              )
            ORDER BY s.stonad_id ASC, vedtak_id ASC, dato_innv_fom DESC
       """,
             values,

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/utils/InfotrygdPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/utils/InfotrygdPeriodeUtil.kt
@@ -14,10 +14,38 @@ import java.time.LocalDate
 object InfotrygdPeriodeUtil {
     fun filtrerOgSorterPerioderFraInfotrygd(perioderFraInfotrygd: List<Periode>): List<Periode> =
         perioderFraInfotrygd
+            .velgKodeMedHøyestPresedensPerVedtak()
             .toSet()
             .map { brukOpphørsdatoSomTomHvisDenFinnes(it) }
             .filter { it.stønadTom > it.stønadFom } // Skal infotrygd rydde bort disse? (inkl de der opphørdato er før startdato)
             .sortedWith(compareBy<Periode>({ it.stønadId }, { it.vedtakId }, { it.stønadFom }).reversed())
+
+    /**
+     * Et vedtak kan ha flere rader i t_endring (PK er vedtak_id og kode), for eksempel når en sak i
+     * ettertid får en ny kode (opphørt eller overført ny løsning) i tillegg til den opprinnelige.
+     * Uten en deterministisk prioritering her ville hvilken av radene som "vinner" avhenge av
+     * databasens tilfeldige/udefinerte returrekkefølge, noe som førte til avvik mellom on-prem og
+     * GCP-replikaen for sammenslåtte perioder. Vi velger derfor koden med høyest presedens, samme
+     * prioritering som allerede gjøres klient-side i ef-sak-frontend (grupperInfotrygdperiode.ts)
+     * når flere endringer for samme vedtak vises.
+     * Vi grupperer på hele perioden (utenom kode) fremfor kun vedtakId, slik at vi kun slår sammen
+     * rader som faktisk er duplikater av samme vedtak (og ikke f.eks. ulike stønadId/vedtak som i
+     * praksis aldri vil dele vedtakId, men som enkelte tester bevisst konstruerer med samme id).
+     * NB: dette gjelder kun sammenslåtte perioder - hentPerioder() returnerer fortsatt alle radene,
+     * slik at konsumenter som viser rådata (f.eks. migreringsoversikten) fortsatt ser alle endringene.
+     */
+    private fun List<Periode>.velgKodeMedHøyestPresedensPerVedtak(): List<Periode> =
+        groupBy { it.copy(kode = InfotrygdEndringKode.NY) }
+            .values
+            .map { perioderMedUlikKode -> perioderMedUlikKode.maxBy { kodePresedens(it.kode) } }
+
+    private fun kodePresedens(kode: InfotrygdEndringKode): Int =
+        when (kode) {
+            InfotrygdEndringKode.OVERTFØRT_NY_LØSNING -> 3
+            InfotrygdEndringKode.UAKTUELL -> 2
+            InfotrygdEndringKode.OPPHØRT -> 1
+            else -> 0
+        }
 
     private fun brukOpphørsdatoSomTomHvisDenFinnes(it: Periode): Periode {
         val opphørsdato = it.opphørsdato

--- a/src/test/kotlin/no/nav/familie/ef/infotrygd/perioder/InfotrygdPeriodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/infotrygd/perioder/InfotrygdPeriodeUtilTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.infotrygd.perioder
 
 import no.nav.familie.ef.infotrygd.perioder.InfotrygdPeriodeTestUtil.lagInfotrygdPeriode
+import no.nav.familie.ef.infotrygd.rest.api.InfotrygdEndringKode
 import no.nav.familie.ef.infotrygd.utils.InfotrygdPeriodeUtil.filtrerOgSorterPerioderFraInfotrygd
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -100,6 +101,30 @@ internal class InfotrygdPeriodeUtilTest {
 
         assertThat(nyePerioder).hasSize(1)
         assertThat(nyePerioder[0]).isEqualTo(periode)
+    }
+
+    @Test
+    internal fun `skal velge kode med høyest presedens når vedtaket har flere endringskoder`() {
+        // De to periodene representerer samme vedtak/rad i t_vedtak, men to ulike t_endring-rader
+        // (kun kode skiller de), derfor bygges den ene som en kopi av den andre.
+        val førstegangsvedtak = lagInfotrygdPeriode(kode = InfotrygdEndringKode.FØRSTEGANGSVEDTAK)
+        val opphørt = førstegangsvedtak.copy(kode = InfotrygdEndringKode.OPPHØRT)
+
+        val nyePerioder = filtrerOgSorterPerioderFraInfotrygd(listOf(førstegangsvedtak, opphørt))
+
+        assertThat(nyePerioder).hasSize(1)
+        assertThat(nyePerioder[0].kode).isEqualTo(InfotrygdEndringKode.OPPHØRT)
+    }
+
+    @Test
+    internal fun `skal velge overført ny løsning fremfor opphørt når vedtaket har flere endringskoder`() {
+        val opphørt = lagInfotrygdPeriode(kode = InfotrygdEndringKode.OPPHØRT)
+        val overførtNyLøsning = opphørt.copy(kode = InfotrygdEndringKode.OVERTFØRT_NY_LØSNING)
+
+        val nyePerioder = filtrerOgSorterPerioderFraInfotrygd(listOf(opphørt, overførtNyLøsning))
+
+        assertThat(nyePerioder).hasSize(1)
+        assertThat(nyePerioder[0].kode).isEqualTo(InfotrygdEndringKode.OVERTFØRT_NY_LØSNING)
     }
 
     @Test


### PR DESCRIPTION
Endepunktet hentPerioder gjør ingen sammenslåing på perioder og vedtak, så dersom et vedtak har to endringskoder, vil det vises som to like rader, men med ulik endringskode. Feilen som ble funnet ifbm skyggekjøring gjelder altså kun slåSammenInfotrygd-perioder endepunktet. Etter nærmere undersøkelse så jeg at det finnes prioritering av endringskoder i familie-ef-sak-frontend.

Kodenes prioritet er følgende: 
1. Overført ny løsning
2. Uaktuell 
3. Opphørt.
4. resterende koder

I praksis er det opphør som er viktigst her, da mest data med to endringer pr vedtak gjelder opphør.

Jeg har tatt noen stikkprøver og ser at den sorteringen gir mening, for det ser ut til at man ikke kan basere seg på sist oppdatert tidspunkt, slik som først antatt. Endepunktet slåSammenPerioder brukes til å gi vedtaksoversikt i ef-sak, i tillegg til at den brukes av Arena/Bisys/Tilleggsstønader.
hentPerioder er brukt i ef-sak grunnlagsdata blant annet, for å svare ja/nei på om bruker har hatt vedtak i infotrygd.