### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -31,7 +31,7 @@ spec:
       memory: 512Mi  # app will be killed if exceeding these limits
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 20m
-      memory: 256Mi
+      memory: 512Mi
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-ef-infotrygd.intern.dev.nav.no
     - https://familie-ef-infotrygd.dev-fss-pub.nais.io

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -31,7 +31,7 @@ spec:
       memory: 1024Mi  # app will be killed if exceeding these limits
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 50m
-      memory: 512Mi
+      memory: 1024Mi
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-ef-infotrygd.intern.nav.no
     - https://familie-ef-infotrygd.prod-fss-pub.nais.io


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
