### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -30,7 +30,7 @@ spec:
     limits:
       memory: 512Mi  # app will be killed if exceeding these limits
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
-      cpu: 20m
+      cpu: 50m
       memory: 512Mi
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-ef-infotrygd.intern.dev.nav.no

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -28,10 +28,10 @@ spec:
   preStopHookPath: "" # Optional. A HTTP GET will be issued to this endpoint at least once before the pod is terminated.
   resources: # Optional. See: http://kubernetes.io/docs/user-guide/compute-resources/
     limits:
-      memory: 1024Mi  # app will be killed if exceeding these limits
+      memory: 704Mi  # app will be killed if exceeding these limits
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 50m
-      memory: 1024Mi
+      memory: 704Mi
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-ef-infotrygd.intern.nav.no
     - https://familie-ef-infotrygd.prod-fss-pub.nais.io


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.